### PR TITLE
Fix ESLint config and remove unused imports to unblock Vercel deployment

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { motion, useAnimation, useInView } from "framer-motion";

--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { motion, useInView } from "framer-motion";
 import { Filter, Download, Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -6,7 +6,7 @@ import { Filter, Download, Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import LabStep from "@/components/labs/LabStep";
-import { AcceptanceCriteria, TopicHierarchy, DEFAULT_HIERARCHY } from "@/data";
+import { AcceptanceCriteria, DEFAULT_HIERARCHY } from "@/data";
 import { filterLabs, getPersonas, getTopics, getAreas, getProblems } from "@/lib/lab-utils";
 import SelectFilter from "@/components/labs/SelectFilter";
 import { getPersonaIntro } from "@/data";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import LandingPage from "@/components/LandingPageAnmol";
 import FeaturePage from "@/components/FeaturesAnmol";
 import Assessments from "@/components/Assessments";

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Link from "next/link";
 import { FileText, Calendar } from "lucide-react";
 

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import Image from "next/image";
-import { FileText, ExternalLink, Calendar } from "lucide-react";
+import { FileText, Calendar } from "lucide-react";
 
 const TalksPage = () => {
   return (

--- a/components/FeaturePage.tsx
+++ b/components/FeaturePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { motion, useInView } from "motion/react";
 import FeatureBox from "./FeatureBox";
 import { FEATURES } from "@/constants";

--- a/components/FeaturesAnmol.tsx
+++ b/components/FeaturesAnmol.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { motion, useInView } from "motion/react";
 
 export default function FeaturesAnmol() {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Github, Mail, Twitter, ExternalLink } from "lucide-react";

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 const LandingPage = () => {

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import Image from "next/image";
 import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 const LandingPage = () => {

--- a/components/LandingPageAnmol.tsx
+++ b/components/LandingPageAnmol.tsx
@@ -3,9 +3,6 @@
 import React from "react";
 import Link from "next/link";
 
-import FeaturesAnmol from "./FeaturesAnmol";
-import Assessments from "./Assessments";
-import PersonasPageAnmol from "./PersonasPageAnmol";
 
 const LandingPageA: React.FC = () => {
   return (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Menu, X } from "lucide-react";
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { NavlinkType, NAVLINKS } from "@/constants";
 import Image from "next/image";
 import Link from "next/link";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
-import Assessments from "./Assessments";
 import { Menu, X } from "lucide-react";
 
 const Navbar = () => {

--- a/components/PartnershipsPage.tsx
+++ b/components/PartnershipsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 const Partnership = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/components/PersonasPage.tsx
+++ b/components/PersonasPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { ArrowRight } from "lucide-react";
 import { PersonaType, PERSONAS } from "@/constants";
 import Image from "next/image";

--- a/components/TestimonialsPage.tsx
+++ b/components/TestimonialsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { motion, useAnimation, useInView } from "framer-motion";
 
 // Student testimonials data - anonymous quotes

--- a/components/labs/LabStep.tsx
+++ b/components/labs/LabStep.tsx
@@ -19,7 +19,6 @@ interface LabStepProps {
 
 const LabStep: React.FC<LabStepProps> = ({
   step,
-  index,
   copyToClipboard,
   caseStudy,
   isSecondStep,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,24 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import nextPlugin from "@next/eslint-plugin-next";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+const tsRecommended = tsPlugin.configs["flat/recommended"];
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  // TypeScript recommended (flat config)
+  ...(Array.isArray(tsRecommended) ? tsRecommended : [tsRecommended]),
+  // Next.js core web vitals (flat config)
+  nextPlugin.flatConfig.coreWebVitals,
+  // Override parser for TS files
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        sourceType: "module",
+      },
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,7 +1218,6 @@
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1269,7 +1268,6 @@
       "integrity": "sha512-5w64ZeRCgWOA/2ADPoFYmDYdPnEeEkUiFx5Sez7MQpQuxVazHO9wwl+wElokaY5hMKVVor1N13z/tZeWYfVaUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.0",
         "@typescript-eslint/types": "8.30.0",
@@ -1703,7 +1701,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2584,7 +2581,6 @@
       "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2759,7 +2755,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4895,7 +4890,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4905,7 +4899,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5587,7 +5580,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5737,7 +5729,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@typescript-eslint/eslint-plugin": "^8.30.0",
+    "@typescript-eslint/parser": "^8.30.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
- Rewrite eslint.config.mjs to use flat config API directly, bypassing FlatCompat which was broken by @typescript-eslint/eslint-plugin@8.30.0
- Remove unused imports/variables across 7 files