### PR TITLE
[BUG] Fix placeholder links and text errors across multiple pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -327,7 +327,7 @@ export default function AboutPage() {
               <ArrowRight size={18} className="ml-2" />
             </Link>
             <a
-              href="https://github.com/yourusername/your-repo"
+              href="https://github.com/BrunelTalentMarketplace/se-education-toolkit"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center px-8 py-3 bg-blue-700 text-white rounded-full font-medium hover:bg-blue-800 transition-colors"

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -93,7 +93,6 @@ const TalksPage = () => {
               <Link href="/" className="hover:text-blue-300">Home</Link>
               <Link href="/about" className="hover:text-blue-300">About</Link>
               <Link href="/talks" className="text-blue-300 font-medium">Talks</Link>
-              <Link href="/contact" className="hover:text-blue-300">Contact</Link>
             </div>
           </div>
           <div className="mt-6 pt-6 border-t border-gray-700 text-center text-gray-400 text-sm">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,7 +11,6 @@ const Footer = () => {
     { name: "Home", href: "/" },
     { name: "About", href: "/about" },
     { name: "Labs", href: "/labs" },
-    { name: "Contact", href: "/contact" },
   ];
 
   const socialLinks = [

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Github, Mail, Twitter, ExternalLink } from "lucide-react";
+import { Github, ExternalLink } from "lucide-react";
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -17,18 +17,8 @@ const Footer = () => {
   const socialLinks = [
     {
       name: "GitHub",
-      href: "https://github.com",
+      href: "https://github.com/BrunelTalentMarketplace",
       icon: <Github size={18} />,
-    },
-    {
-      name: "Twitter",
-      href: "https://twitter.com",
-      icon: <Twitter size={18} />,
-    },
-    {
-      name: "Email",
-      href: "mailto:info@se-toolkit.com",
-      icon: <Mail size={18} />,
     },
   ];
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -107,20 +107,6 @@ const Footer = () => {
           <p className="text-xs text-gray-500 text-center md:text-left">
             © {currentYear} SE Toolkit. All rights reserved.
           </p>
-          <div className="flex gap-4 mt-4 md:mt-0">
-            <Link
-              href="/privacy"
-              className="text-xs text-gray-500 hover:text-blue-500"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms"
-              className="text-xs text-gray-500 hover:text-blue-500"
-            >
-              Terms of Service
-            </Link>
-          </div>
         </motion.div>
       </div>
     </footer>

--- a/components/labs/CaseStudyHierarchy.tsx
+++ b/components/labs/CaseStudyHierarchy.tsx
@@ -29,7 +29,7 @@ const CaseStudyHierarchy: React.FC<CaseStudyHierarchyProps> = ({
   const showUserStory = hierarchy.levels.includes("userStory");
   const showAcceptanceCriteria = hierarchy.levels.includes("acceptanceCriteria");
   const userStoryLabel = hierarchy.labels.userStory ?? "User Story";
-  const userStoriesLabel = `${userStoryLabel}s`;
+  const userStoriesLabel = userStoryLabel === "User Story" ? "User Stories" : `${userStoryLabel}s`;
   const acLabel = hierarchy.labels.acceptanceCriteria ?? "Acceptance Criteria";
   const [expandedProblems, setExpandedProblems] = useState<Set<string>>(new Set());
   const [expandedUserStories, setExpandedUserStories] = useState<Set<string>>(new Set());

--- a/components/labs/CaseStudyHierarchy.tsx
+++ b/components/labs/CaseStudyHierarchy.tsx
@@ -29,7 +29,7 @@ const CaseStudyHierarchy: React.FC<CaseStudyHierarchyProps> = ({
   const showUserStory = hierarchy.levels.includes("userStory");
   const showAcceptanceCriteria = hierarchy.levels.includes("acceptanceCriteria");
   const userStoryLabel = hierarchy.labels.userStory ?? "User Story";
-  const userStoriesLabel = userStoryLabel === "User Story" ? "User Stories" : `${userStoryLabel}s`;
+  const userStoriesLabel = userStoryLabel.replace(/y$/i, 'ies');
   const acLabel = hierarchy.labels.acceptanceCriteria ?? "Acceptance Criteria";
   const [expandedProblems, setExpandedProblems] = useState<Set<string>>(new Set());
   const [expandedUserStories, setExpandedUserStories] = useState<Set<string>>(new Set());


### PR DESCRIPTION
## Linked Issue
Related to #10

## What Changed and Why
Several placeholder values from the project template were never updated before deployment, resulting in broken links, a spelling error, and references to non-existent pages. This PR fixes all instances identified in issue #10.

## How to Test
1. Navigate to `/labs`, select Requirements Engineering → User Stories and Acceptance Criteria, expand any problem — confirm label now reads "User Stories" not "User Storys"
2. Navigate to `/about`, scroll to bottom, click "View on GitHub" — confirm it now links to the correct repository
3. Scroll to footer on any page — confirm only GitHub icon is present and links to https://github.com/BrunelTalentMarketplace
4. Confirm Contact link is no longer in Quick Links
5. Confirm Privacy Policy and Terms of Service links are no longer in the bottom bar

## Type of Change
- [x] Bug fix

## Checklist
- [x] My changes address only the linked issue — no unrelated modifications
- [x] I have tested the change locally and it works as described
- [x] My commits are logical, atomic, and have meaningful messages
- [x] This PR targets the correct upstream branch (`main` on the teaching repo)

## Notes for Reviewer
Each fix has been committed separately for clarity. Twitter and Email social links have been removed as advised in the issue comments.