### PR TITLE
[ENHANCEMENT] Fix non-functional Deselect button and add Reset button on labs page

### DIFF
--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from "react";
 import { motion, useInView } from "framer-motion";
-import { Filter, Download, Search } from "lucide-react";
+import { Filter, Download, Search, RotateCcw } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import LabStep from "@/components/labs/LabStep";
@@ -180,6 +180,12 @@ const LabsPage = () => {
     downloadLabSheet(selectedLab, personaIntro, selectedHierarchicalData, topicHierarchy);
   };
 
+  const handleReset = () => {
+    setFilters({ area: "", topic: "", persona: "" });
+    setHierarchySelection({ problemId: "", userStoryId: "", acceptanceCriteriaIds: [] });
+    router.push("/labs", { scroll: false });
+  };
+  
   return (
     <main className="min-h-screen flex flex-col items-center relative overflow-hidden px-4 py-10 sm:py-12 md:py-16">
       <div className="absolute inset-0 overflow-hidden -z-10">
@@ -203,7 +209,17 @@ const LabsPage = () => {
             problem and user story to provide context for Part 2.
           </p>
         </motion.div>
-
+{(filters.area || filters.topic || filters.persona || hierarchySelection.problemId) && (
+  <div className="flex justify-end mb-2">
+    <button
+      onClick={handleReset}
+      className="flex items-center gap-2 text-sm text-gray-500 hover:text-red-500 transition-colors border border-gray-200 rounded-lg px-3 py-1.5"
+    >
+      <RotateCcw size={14} />
+      Reset
+    </button>
+  </div>
+)}
         <motion.div
           className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4 mb-6 sm:mb-8"
           initial={{ opacity: 0, y: 20 }}

--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -172,7 +172,8 @@ const LabsPage = () => {
     if (hierarchySelection.problemId) params.set("problemId", hierarchySelection.problemId);
     if (hierarchySelection.userStoryId) params.set("userStoryId", hierarchySelection.userStoryId);
     if (hierarchySelection.acceptanceCriteriaIds.length > 0) params.set("acceptanceCriteriaIds", hierarchySelection.acceptanceCriteriaIds.join(","));
-    router.push(`/labs?${params.toString()}`, { scroll: false });
+    const queryString = params.toString();
+    router.push(queryString ? `/labs?${queryString}` : "/labs", { scroll: false });
   }, [filters, hierarchySelection, router]);
 
   const handleDownload = () => {
@@ -183,7 +184,6 @@ const LabsPage = () => {
   const handleReset = () => {
     setFilters({ area: "", topic: "", persona: "" });
     setHierarchySelection({ problemId: "", userStoryId: "", acceptanceCriteriaIds: [] });
-    router.push("/labs", { scroll: false });
   };
   
   return (
@@ -209,7 +209,12 @@ const LabsPage = () => {
             problem and user story to provide context for Part 2.
           </p>
         </motion.div>
-{(filters.area || filters.topic || filters.persona || hierarchySelection.problemId) && (
+{(filters.area ||
+  filters.topic ||
+  filters.persona ||
+  hierarchySelection.problemId ||
+  hierarchySelection.userStoryId ||
+  hierarchySelection.acceptanceCriteriaIds.length > 0) && (
   <div className="flex justify-end mb-2">
     <button
       onClick={handleReset}

--- a/components/labs/CaseStudyHierarchy.tsx
+++ b/components/labs/CaseStudyHierarchy.tsx
@@ -68,12 +68,12 @@ const CaseStudyHierarchy: React.FC<CaseStudyHierarchyProps> = ({
   };
 
   const selectProblem = (problemId: string) => {
-  const newId = selectedProblemId === problemId ? "" : problemId;
-  setSelectedProblemId(newId);
-  setSelectedUserStoryId("");
-  setSelectedAcceptanceCriteriaIds([]);
-  onSelectionChange({ problemId: newId, userStoryId: "", acceptanceCriteriaIds: [] });
-};
+    const newId = selectedProblemId === problemId ? "" : problemId;
+    setSelectedProblemId(newId);
+    setSelectedUserStoryId("");
+    setSelectedAcceptanceCriteriaIds([]);
+    onSelectionChange({ problemId: newId, userStoryId: "", acceptanceCriteriaIds: [] });
+  };
 
   const selectUserStory = (userStoryId: string) => {
     const newId = selectedUserStoryId === userStoryId ? "" : userStoryId;

--- a/components/labs/CaseStudyHierarchy.tsx
+++ b/components/labs/CaseStudyHierarchy.tsx
@@ -68,11 +68,12 @@ const CaseStudyHierarchy: React.FC<CaseStudyHierarchyProps> = ({
   };
 
   const selectProblem = (problemId: string) => {
-    setSelectedProblemId(problemId);
-    setSelectedUserStoryId("");
-    setSelectedAcceptanceCriteriaIds([]);
-    onSelectionChange({ problemId, userStoryId: "", acceptanceCriteriaIds: [] });
-  };
+  const newId = selectedProblemId === problemId ? "" : problemId;
+  setSelectedProblemId(newId);
+  setSelectedUserStoryId("");
+  setSelectedAcceptanceCriteriaIds([]);
+  onSelectionChange({ problemId: newId, userStoryId: "", acceptanceCriteriaIds: [] });
+};
 
   const selectUserStory = (userStoryId: string) => {
     const newId = selectedUserStoryId === userStoryId ? "" : userStoryId;


### PR DESCRIPTION
## Linked Issue
Related to #14

---

## What Changed and Why
Two selection management issues on the labs page have been addressed:

1. The Deselect button on a selected problem was non-functional, clicking it did nothing. Fixed by updating the `selectProblem` function in `components/labs/CaseStudyHierarchy.tsx` to toggle selection, mirroring the existing logic already used in `selectUserStory`.

2. There was no way to reset all selections at once without refreshing the page. A Reset button has been added to `app/labs/page.tsx` that clears all filters and hierarchy selections in one click and restores the clean `/labs` URL.

## How to Test
1. Navigate to `/labs`
2. Select any Area and Topic - confirm Reset button appears top right
3. Click Reset - confirm all dropdowns clear and URL returns to `/labs`
4. Select a problem - expand it and click Deselect — confirm problem is deselected
5. Select a different problem - confirm it selects correctly
6. Click Reset - confirm everything clears including the problem selection

## Type of Change
- [x] Bug fix
- [x] Enhancement

## Checklist
- [x] My changes address only the linked issue, no unrelated modifications
- [x] I have tested the change locally and it works as described
- [x] My commits are logical, atomic, and have meaningful messages
- [x] This PR targets the correct upstream branch (`main` on the teaching repo)

## Notes for Reviewer
Each fix has been committed separately for clarity. The deselect fix mirrors the existing toggle logic already present in `selectUserStory`. The Reset button only appears when at least one selection has been made, keeping the UI clean when the page is in its default state.